### PR TITLE
Remove transition typing hack.

### DIFF
--- a/src/app/d3-demos/brush-zoom-2/brush-zoom-2.component.ts
+++ b/src/app/d3-demos/brush-zoom-2/brush-zoom-2.component.ts
@@ -89,11 +89,7 @@ export class BrushZoom2Component implements OnInit, OnDestroy {
     }
 
     function zoom() {
-      // HACK: Define transition againt Group Element type `any`
-      // This way it can be reused on SVGGElement and SVGCircleElement, although
-      // it was defined on the SVGSVGElement.
-      // TODO: Update after pending PR with Relaxed constraint is published to DT/@types
-      let t: Transition<any, any, any, any> = d3Svg.transition().duration(750);
+      let t: Transition<SVGSVGElement, any, null, undefined> = d3Svg.transition().duration(750);
       d3Svg.select<SVGGElement>('.axis--x').transition(t).call(xAxis);
       d3Svg.select<SVGGElement>('.axis--y').transition(t).call(yAxis);
       d3Svg.selectAll<SVGCircleElement, [number, number, number]>('circle').transition(t)


### PR DESCRIPTION
- With the updated type definitions for d3-transition the previous HACK in brush-zoom-2.component is no longer required.
